### PR TITLE
A few minor tweaks to the `Hosts` and individual host pages

### DIFF
--- a/static/resourced-master/css/dashboard.css
+++ b/static/resourced-master/css/dashboard.css
@@ -83,6 +83,10 @@ select {
     margin: 0;
 }
 
+.page-header a, .host-name a {
+  color: white;
+}
+
 .nav-tabs li a {
     margin: 0;
 }

--- a/templates/hosts/each-readonly.html.tmpl
+++ b/templates/hosts/each-readonly.html.tmpl
@@ -123,7 +123,7 @@ $('form[role="search"]').submit(function(e) {
     <div class="row">
         <div class="col-lg-12">
             <div class="page-header">
-                <h2>Hosts</h2>
+                <h2><a href="/hosts">Hosts</a></h2>
             </div>
         </div>
     </div>
@@ -135,7 +135,9 @@ $('form[role="search"]').submit(function(e) {
                     <small class="updated-timestamp time-unix-to-local">{{ $.Host.Updated.Unix }}</small>
                 </div>
 
-                <h3>{{ $.Host.Hostname }}</h3>
+                <div class="host-name">
+                    <h3><a href="/hosts/{{ $.Host.ID}}" %>{{ $.Host.Hostname }}</a></h3>
+                </div>
             </div>
 
             {{ range $tagKey, $tagValue := $.Host.GetTags }}

--- a/templates/hosts/each.html.tmpl
+++ b/templates/hosts/each.html.tmpl
@@ -137,7 +137,7 @@ $('form[role="search"]').submit(function(e) {
     <div class="row">
         <div class="col-lg-12">
             <div class="page-header">
-                <h2>Hosts</h2>
+                <h2><a href="/hosts">Hosts</a></h2>
             </div>
         </div>
     </div>
@@ -148,11 +148,13 @@ $('form[role="search"]').submit(function(e) {
                 <div class="pull-right">
                     <small class="updated-timestamp time-unix-to-local">{{ $.Host.Updated.Unix }}</small>
                     <button class="btn btn-xs btn-success" data-toggle="modal" data-target="#tags-modal" data-id="{{ $.Host.ID }}" data-master-tags="{{ $.Host.MasterTags.String }}">
-                        New Tags
+                        Edit Tags
                     </button>
                 </div>
 
-                <h3>{{ $.Host.Hostname }}</h3>
+                <div class="host-name">
+                    <h3><a href="/hosts/{{ $.Host.ID}}" %>{{ $.Host.Hostname }}</a></h3>
+                </div>
             </div>
 
             {{ range $tagKey, $tagValue := $.Host.GetTags }}

--- a/templates/hosts/list-readonly.html.tmpl
+++ b/templates/hosts/list-readonly.html.tmpl
@@ -34,7 +34,6 @@ $(window).load(function() {
     var qValue = ResourcedMaster.url.getParams('q');
     if(qValue) {
         qValue = qValue.replace(/\+/g, ' ');
-
         $('[name="q"]').val(decodeURIComponent(qValue));
         $('form[action="/saved-queries"]').removeClass('hidden');
     }
@@ -132,7 +131,7 @@ $('form[role="search"]').submit(function(e) {
     <div class="row">
         <div class="col-lg-12">
             <div class="page-header">
-                <h2>Hosts</h2>
+                <h2><a href="/hosts">Hosts</a></h2>
             </div>
         </div>
     </div>
@@ -146,7 +145,9 @@ $('form[role="search"]').submit(function(e) {
                     <a href="/hosts/{{ $host.ID }}" class="btn btn-xs btn-success pull-right">Details</a>
                 </div>
 
-                <h3>{{ $host.Hostname }}</h3>
+                <div class="host-name">
+                    <h3><a href="/hosts/{{ $host.ID}}" %>{{ $host.Hostname }}</a></h3>
+                </div>
             </div>
 
             {{ range $tagKey, $tagValue := $host.GetTags }}
@@ -158,6 +159,7 @@ $('form[role="search"]').submit(function(e) {
             {{ end }}
         </div>
     </div>
+    <hr>
     {{ end }}
 </div>
 {{ end }}

--- a/templates/hosts/list.html.tmpl
+++ b/templates/hosts/list.html.tmpl
@@ -145,7 +145,7 @@ $('form[role="search"]').submit(function(e) {
     <div class="row">
         <div class="col-lg-12">
             <div class="page-header">
-                <h2>Hosts</h2>
+                <h2><a href="/hosts">Hosts</a></h2>
             </div>
         </div>
     </div>
@@ -159,13 +159,15 @@ $('form[role="search"]').submit(function(e) {
                     <a href="/hosts/{{ $host.ID }}" class="btn btn-xs btn-success pull-right">Details</a>
                 </div>
 
-                <h3>{{ $host.Hostname }}</h3>
+                <div class="host-name">
+                    <h3><a href="/hosts/{{ $host.ID}}" %>{{ $host.Hostname }}</a></h3>
+                </div>
             </div>
 
             <div>
                 <div class="pull-right">
                     <button class="btn btn-xs btn-success pull-right" data-toggle="modal" data-target="#tags-modal" data-id="{{ $host.ID }}" data-master-tags="{{ $host.MasterTags.String }}">
-                        New Tags
+                        Edit Tags
                     </button>
                 </div>
 
@@ -179,6 +181,7 @@ $('form[role="search"]').submit(function(e) {
             </div>
         </div>
     </div>
+    <hr>
     {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
- Renames `New Tags` to `Edit Tags`
- Updates the `Hosts` word to be a link to /hosts
- Updates the individual hostnames to be a link to their /hosts/ID
- adds an `<hr>` to visually separate the hosts from eachother.

The `<hr>` is pretty jankey and I admittedly know little about css and
html. Might want to refine this to stripe the table.
